### PR TITLE
yepppi / 4_week

### DIFF
--- a/Baekjoon/4_week/yepppi/1325.py
+++ b/Baekjoon/4_week/yepppi/1325.py
@@ -1,0 +1,38 @@
+import sys
+input = sys.stdin.readline
+
+from collections import deque
+
+n, m = map(int, input().split())
+graph = [[] for _ in range(n+1)]
+
+for _ in range(m):
+    end, start = map(int, input().split())
+    graph[start].append(end)
+
+queue = deque()
+
+def bfs(num):
+    visited = [False for _ in range(n+1)]
+    visited[num] = True
+    
+    count = 1
+    queue.append(num)
+    
+    while queue:
+        now = queue.popleft()
+        for next in graph[now]:
+            if visited[next] == False:
+                visited[next] = True
+                queue.append(next)
+                count += 1
+    return count
+
+result = [0 for _ in range(n+1)]
+for i in range(1, n+1):
+    result[i] = bfs(i)
+    
+answer = max(result)
+for i in range(len(result)):
+    if result[i] == answer:
+        print(i, end=' ')

--- a/Baekjoon/4_week/yepppi/6236.py
+++ b/Baekjoon/4_week/yepppi/6236.py
@@ -1,0 +1,38 @@
+n, m = map(int, input().split())
+money = []
+
+for _ in range(n):
+    money.append(int(input().rstrip()))
+    
+start, end = min(money), sum(money)
+answer = sum(money)
+    
+while start <= end:
+    mid = (start + end) // 2
+    
+    times = 1
+    count = 0
+    is_small = False
+    
+    for budget in money:
+        
+        if budget > mid:
+            is_small = True
+            break
+        
+        if count + budget > mid:
+            times += 1
+            count = budget
+        else:
+            count += budget
+    
+    if is_small == True:
+        start = mid + 1
+    else:
+        if times > m:
+            start = mid + 1
+        else:
+            end = mid - 1
+            answer = min(answer, mid)
+
+print(answer)

--- a/Baekjoon/4_week/yepppi/7562.py
+++ b/Baekjoon/4_week/yepppi/7562.py
@@ -1,0 +1,34 @@
+import sys
+input = sys.stdin.readline
+
+from collections import deque
+
+T = int(input().rstrip())
+
+for _ in range(T):
+    I = int(input().rstrip())
+    startX, startY = map(int, input().split())
+    endX, endY = map(int, input().split())
+    
+    dx = [-1, -1, 1, 1, -2, -2, 2, 2]
+    dy = [-2, 2, -2, 2, -1, 1, -1, 1]
+    
+    visited = [[False for _ in range(I)] for _ in range(I)]
+    
+    queue = deque()
+    queue.append((startX, startY, 0))
+    
+    while queue:
+        x, y, count = queue.popleft()
+        visited[x][y] = True
+        
+        if x == endX and y == endY:
+            print(count)
+            continue
+        
+        for i in range(8):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0<=nx<I and 0<=ny<I and visited[nx][ny] == False:
+                queue.append((nx, ny, count+1))
+                visited[nx][ny] = True


### PR DESCRIPTION
## 첫 번째 문제(7662번) 풀이 방법

결론부터 말씀드리면, 해결 못했습니다... 코테 문제 풀이 마감이 목요일(오늘)까지라 우선 해결한 부분까지라도 가져왔습니다.

```
import sys
input = sys.stdin.readline
sys.setrecursionlimit(10**9)

import heapq

T = int(input().rstrip())

maxheap = []
minheap = []
visited = []
count = 0
key = 0

for _ in range(T):
    k = int(input().rstrip())

    for i in range(k):
        value, n = map(str, input().split())
        
        if value == 'I':
            heapq.heappush(minheap, (int(n), key))
            heapq.heappush(maxheap, (int(n)*(-1), key))
            visited.append(True)
            count += 1
            key += 1
            continue
        else:
            if len(maxheap) + len(minheap) <= count:
                print('EMPTY')
                continue
            else:
                if n == '-1':
                    tmp, seq = heapq.heappop(minheap)
                else:
                    tmp, seq = heapq.heappop(maxheap)
                visited[seq] = False

minimum, maximum = 0, 0
for i in range(len(visited)):
    if visited[i] == True and minheap[0][1] == i:
        minimum = minheap[0][0]
    elif visited[i] == True and maxheap[0][1] == i:
        maximum = -maxheap[0][0]
        
print(maximum, minimum)
```

### 접근 방식
개인적으로 고민을 많이 한 문제다. 10가지 넘게, 정말 여러 방식으로 풀이를 도전했지만 계속되는 시간 초과와 메모리 초과 오류로 계속해서 다른 방법을 고민해야만 했다. 그렇게 얼핏 가닥을 잡아가는 듯 했지만 결국 해결은 못한 상황이다.

우선순위 큐라는 단어를 보자마자 힙을 써야한다는 것을 캐치할 수 있었고, 최솟값과 최댓값을 출력하라는 점에서 두 개의 힙을 사용하면 되겠다는 생각을 바로 했다. 그러나, 코테 스터디 질문방에 올라왔던 내용처럼 나 또한 두 힙 간 동기화 방법이 문제였다.

### 코드 설명
힙에 key 즉, 해당 숫자를 넣게 된 순서를 같이 넣어주고 visited 값에 변화를 주어 이후에 큐에 남아있으면서도, 최솟값이자 최댓값인 값을 출력해주고자 하였다.

count 값을 통해 최대힙과 최소힙에 값이 남아있더라도 실제로는 큐가 비어있는 상태인 경우를 체크하여 EMPTY를 출력해주었다.

### 후기
문제점을 찾은 상태다. 반례로는, 결국 큐에 값이 하나 남아있는 경우, 이미 빠져서 큐에 없다고 판단되는 값이 힙에서의 최소 혹은 최댓값일 경우 다. 두 가지에 관해 고쳐주고 나면 될 것 같은데 초과 오류가 뜨지 않을 수 있을지 걱정이다.


<br>

## 두 번째 문제(7562번) 풀이 방법

### 접근 방식
문제의 그림을 보고 더 쉽게 문제에 접근할 수 있었다. 나이트가 시작점에서 끝점까지 이동할 수 있는 최소값을 구하는 문제이기 때문에 BFS를 생각해서 풀게 되었다.

### 코드 설명
dx 와 dy 는 나이트가 이동할 수 있는 경로대로 설정해주었고, 총 8가지다.

visited를 통해 방문여부를 체크해주었고, 만약 queue에서 꺼낸 x와 y가 목적지와 같다면 현재 count를 출력한 후 continue를 통해 다음으로 넘어갈 수 있도록 하였다.

queue에 nx, ny를 넣어줄 때는 count에 1을 더한 값을 넘겨주어 이동횟수를 셀 수 있도록 했다.

특별히 어려운 점은 없었고, 전형적인 bfs 탐색문제였다.

### 후기
i를 이중변수로 사용해버리는 바람에 값이 제대로 나오지 않는 오류를 중간에 범했다. 그 부분을 찾지 못해 한참 고생했지만 제외하고 어려운 부분은 하나도 없었던 것 같다.


<br>

## 세 번째 문제(1325번) 풀이 방법

### 접근 방식
`한 번의 해킹으로 여러 개의 컴퓨터를 해킹 할 수 있는` 이란 조건을 보고 바로 DFS를 떠올릴 수 있었다. `신뢰하는 관계` 와 `신뢰하지 않는 관계` 로 이루어져 있으므로 단방향임을 확인할 수 있었다.

DFS로 풀어서 제출했는데 Python3에서 `시간 초과` 가 나고, Pypy3에서 `메모리 초과` 가 나는 것을 보고 재귀 때문임을 알 수 있었다. 재귀를 사용하지 않기 위해서 deque를 사용하게 되었고 결국 BFS로 풀게 되었다.

### 코드 설명
start와 end 값이 반대로 입력되는 것을 캐치하고 graph 리스트를 만들어줄 수 있도록 했다.

deque를 통해 값을 넣었다 빼며 bfs 알고리즘을 진행했고, 해당 횟수마다 count를 증가시켜 시작한 지점에서 다른 지점으로 총 몇 번을 갈 수 있는지 확인해주었다.

해당 값을 result 리스트에 저장시켰다가 가장 큰 값을 지닌 인덱스를 출력해주었다.

### 후기
거의 10번의 시간 초과를 맛봤는데, 

```python
sys.setrecursionlimit(10**6)
```

해당 코드 때문이었다 … 아마 재귀가 없는데도 recursion 계산을 하다 보니 시간 초과가 난 게 아닐까 라는 생각이 든다.


<br>


## 네 번째 문제(6236번) 풀이 방법

### 접근 방식
최소 금액 K를 구해야 하는 문제라 탐색을 떠올렸고, 머지 않아 이분탐색을 떠올리게 되었다.

N일동안 금액을 사용하므로 N과 금액의 범위를 확인해주었다. 최악의 경우, 100,000일 동안 최소 1원에서 10,000원까지 사용할 수 있으므로 1,000,000,000(1억)번의 계산이 필요할 수도 있다. 따라서, 이분탐색으로 문제를 푸는 것이 맞다는 생각이 들었다.

→ 맞게 계산한 건지 잘 모르겠습니다…! 틀렸다면 comment 남겨주시면 조언 받아서 다시 고민해볼게요!

### 코드 설명
start와 end 값을 정할 때는 min 값과 max 로 하면 되겠다는 막연한 생각을 갖고 있다가 코드를 직접 칠 때 아차 하면서 sum 이 최댓값이 되겠다는 생각이 바로 들어 값을 잘 정해줄 수 있었다.

times 는 인출 횟수를 체크해주는 변수고, count 는 인출 금액을 체크해주는 변수다. is_small 이라는 boolean 변수를 두어 애초에 mid 값이 사용할 금액보다 적은 경우가 있다면 계산을 해주지 않도록 했다.

인출 횟수가 m보다 크다면 더 많은 금액으로 인출해야 하므로 start 값을 변경해주었다.

### 후기
이분 탐색 문제임을 알고 나서 금방 풀 수 있겠다라는 생각이 들었는데 은근히 생각할 부분이 있었다. 물론 start와 end 의 초기값을 금방 알아채기는 했지만 실수하기 쉬운 부분이기도 했고, 이후 어떤 경우에 따라 어떻게 start와 end 값을 바꿔주어야 하는지 헷갈렸다. 그래도, 결론적으로는 난이도가 높은 문제는 아니었던 것 같다.


<br>

