### PR TITLE
sojin/4_week

### DIFF
--- a/Baekjoon/4_week/sojin/나이트의이동.py
+++ b/Baekjoon/4_week/sojin/나이트의이동.py
@@ -1,0 +1,31 @@
+#7562번 나이트의 이동
+
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+dx = [-1, 1, 2, 2, 1, -1, -2, -2]
+dy = [2, 2, 1, -1, -2, -2, -1, 1]
+
+def bfs():
+    q = deque()
+    q.append((sx, sy))
+    while q :
+        x, y = q.popleft()
+        if x == ex and y == ey :
+            return chess[x][y] -1
+        for i in range(8) :
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0<=nx<l and 0<=ny<l and chess[nx][ny]==0:
+                chess[nx][ny] = chess[x][y] + 1
+                q.append((nx,ny))
+
+t= int(input())
+for _ in range(t) :
+    l = int(input())
+    chess = [[0]*l for _ in range(l)]
+    sx, sy = map(int, input().split())
+    ex, ey = map(int, input().split())
+    chess[sx][sy]=1
+    print(bfs())

--- a/Baekjoon/4_week/sojin/용돈관리.py
+++ b/Baekjoon/4_week/sojin/용돈관리.py
@@ -1,0 +1,28 @@
+#
+
+import sys
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+money = [int(input()) for _ in range(n)]
+
+start = min(money)
+end = sum(money)
+
+while start <= end:
+    mid = (start + end) // 2
+    now = mid
+    num = 1
+    for i in range(n):
+        if now < money[i]:
+            now = mid
+            num += 1
+        now -= money[i]
+
+    if num > m or mid < max(money):
+        start = mid + 1
+    else:
+        end = mid - 1
+        k = mid
+
+print(k)

--- a/Baekjoon/4_week/sojin/이중우선순위큐.py
+++ b/Baekjoon/4_week/sojin/이중우선순위큐.py
@@ -1,0 +1,45 @@
+#7662번 이중 우선순위 큐
+
+import sys
+import heapq
+input = sys.stdin.readline
+
+def sync(arr):
+    while arr and visited[arr[0][1]] == 0:
+        heapq.heappop(arr)
+
+for _ in range(int(input())):
+    min_heap, max_heap = [], []
+    visited = [0] * 1000000
+
+    k = int(input())
+    for i in range(k):
+        op, num = input().split()
+        num = int(num)
+
+        if op == "I":
+            heapq.heappush(min_heap, (num, i))
+            heapq.heappush(max_heap, (-num, i))
+            visited[i] = 1
+            
+        else:
+            if num == 1:
+                sync(max_heap)
+                if max_heap:
+                    visited[max_heap[0][1]] = 0
+                    heapq.heappop(max_heap)
+
+            elif num == -1:
+                sync(min_heap)
+                if min_heap:
+                    visited[min_heap[0][1]] = 0
+                    heapq.heappop(min_heap)
+
+sync(max_heap)
+sync(min_heap)
+
+if min_heap and max_heap:
+    print(-max_heap[0][0], min_heap[0][0])
+
+else:
+    print('EMPTY')

--- a/Baekjoon/4_week/sojin/효율적인해킹.py
+++ b/Baekjoon/4_week/sojin/효율적인해킹.py
@@ -1,0 +1,42 @@
+#1325번 효율적인 해킹
+
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+n, m = map(int,input().split())
+
+def bfs(v):
+    cnt = 1
+    queue = deque()
+    queue.append(v)
+    visited = [0]*(n+1)
+    visited[v] = 1
+    while queue:
+        x = queue.popleft()
+        for nx in com[x]:
+            if visited[nx] == 0:
+                visited[nx] = 1
+                cnt += 1
+                queue.append(nx)
+    return cnt
+
+com = [[] for _  in range(n+1)]
+
+for _ in range(m):
+    t, td = map(int, input().split())
+    com[td].append(t)
+
+max_cnt = 0
+results = []
+
+for i in range(1,n+1):
+    cnt = bfs(i)
+    if cnt > max_cnt:
+        max_cnt = cnt
+        results.clear()
+        results.append(i)
+    elif cnt == max_cnt:
+        results.append(i)
+
+print(*results)


### PR DESCRIPTION
## 첫 번째 문제(7662번) 풀이 방법

### 접근 방식
중복 가능과 우선순위라는 키워드를 보고 힙을 사용해야겠다고 떠올리고 문제에 접근했다.
힙은 자동으로 인덱스 0이 가장 최솟값이 되도록 정렬을 한다. 파이썬에서는 최소 힙만 지원하므로 최댓값을 찾는 힙에는 -를 붙여 삽입 되도록 했다.
최소힙과 최대힙을 동기화하여 이미 삭제된 값을 또 삭제하지 않도록 하기로 하고 구현을 시작했다.(동기화 부분은 감이 안 잡혀서 구글링을 통해 힌트를 얻었습니다.) 

### 코드 설명
7-9 : max_heap과 min_heap을 동기화 하는 함수로 만약 인덱스 0 값(=최대값, 최소값)이 0 즉 이미 삭제된 값이라면 힙에서 제거한다.
16-18 : 연산자를 op에 받고 정수는 num으로 받는다.
20-23 : 만약 연산자가 "I"라면 삽입해야 하므로 min_heap에는 num과 인덱스 값을 같이 넣고 max_heap에는 -를 붙여 인덱스 값과 같이 넣는다. 이때, 인덱스 값을 넣는 이유는 동기화를 위해서다.
25-30 : 만약 D 1이라면 먼저 동기화를 통해 최솟값이 이미 최대값힙에서 삭제되어 있는지 확인을 하고 삭제를 한다.
32-36 : 최솟값 힙도 위와 같이 확인 및 삭제한다.
38-39 : 각각 동기화를 한 번 더 해서 쓰레기 값을 없앤다.

### 후기
이 코드도 수정을 거듭했지만 시간 초과가 납니다. 힙을 쓰는건 맞는 것 같은데 삭제를 하는 과정이 문제인 것 같기도한데 다른 방법이 도저히 생각이나지 않습니다...


<br>

## 두 번째 문제(1325번) 풀이 방법

### 접근 방식
신뢰 관계의 컴퓨터를 연결하여 bfs로 탐색해야겠다는 생각으로 접근을 했다.
컴퓨터의 개수만큼 리스트를 구성하고 for문을 돌려 신뢰를 받는 컴퓨터의 리스트에 신뢰를 하는 컴퓨터를 넣었다.
이후, bfs를 돌려 각 컴퓨터와 연결된 컴퓨터를 카운트하고 출력하는 방식으로 구성했다.

### 코드 설명
24-28 : 컴퓨터만큼 리스트를 선언하고 신뢰받는 컴퓨터 리스트에 신뢰하는 컴퓨터를 추가한다.
9-22 : 각 컴퓨터들을 시작으로 인접한 노드(신뢰 관계)를 방문하여 cnt를 하나씩 올린다.
33-42 : 각각의 컴퓨터의 cnt 중 최댓값을 가지는 컴퓨터를 배열에 넣고 같아도 배열에 추가하여 결과를 출력한다.

### 후기
코드가 아무리 수정을 해도 시간 초과가 납니다... 반복문이 많은 것 같기는 한데 다른 방법이 생각이 나지 않네요.. 회의 전까지 수정할 수 있으면 해보겠습니다..


<br>

## 세 번째 문제(6236번) 풀이 방법

### 접근 방식
최소 금액(k)을 계산하라는 문장을 보고 이진탐색으로 구현을 해야겠다고 생각했다.
돈을 너무 많이 인출하거나 하루에 이용하는 금액보다 K가 작으면 인출하는 양(K)이 너무 작은 것이므로 시작값을 조정하고  인출 횟수가 m보다 작거나 같으면 인출 금액이 너무 많은 것이므로 끝값을 조정하여 이진탐색을 한다.

### 코드 설명
money => 하루에 쓰는 돈
num => 인출 횟수
15-20 : 현재 가지고 있는 돈보다 오늘 사용해야하는 돈이 많을 경우 가지고 있는 돈을 다시 넣고 k만큼 인출하기 때문에 `now = mid` 한 번 인출을 했으므로 num을 1 올리고, 오늘 사용한 돈을 뺸다.
22-23 : m번보다 더 많이 인출하거나 인출한 금액이 하루 사용량보다 적은 경우 인출 금액이 적은 것이므로 시작값을 조정한다. `start = mid + 1`
24-26:다른 경우는 인출 횟수가 m보다 작은 경우로 인출 금액이 많기 문에 끝값을 조정한다. `end = mid - 1`

### 후기
이 문제가 네 문제 중에 유일하게 고민 없이 푼 문제 같네요. 확실히 매주 반복하니깐 문제를 읽으면 바로 이진탐색을 써야겠다는 생각이 드는 것 같습니다.


<br>


## 네 번째 문제(7562번) 풀이 방법

### 접근 방식
저번 주와 비슷한 방식으로 방향 리스트를 미리 저장해서 bfs로 탐색해야겠다고 생각했다. 

### 코드 설명
7-8 : 나이트가 이동할 수 있는 좌표를 방향 리스트로 미리 구현
10-12 : bfs()의 정의로 deque로 큐를 만들어 시작 좌표를 append한다.
13-16 : 맨 앞 노드를 꺼내 최종 좌표와 같은지를 확인하고 같다면 `chess[x][y]-1 `값을 리턴한다. 여기서 -1을 하는 이유는 처음에 시작을 1로 했기 때문이다.
17-22:방향 리스트를 더해서 만약 체스판 범위에 벗어나지 않고 방문하지 않은 노드라면  이전 노드에 +1을 하고 큐에 삽입한다.

### 후기
저번 주에는 방향이 네 방향이라 방향 리스트 없이 노드 좌표를 직접 지정해서 넣었는데 이번 주차 문제는 너무 지저분해질 것 같아 방향 리스트를 써봤습니다. 저번 주에 비슷한 유형을 안 풀어봤다면 다른 분들의 풀이를 보지 못하고 또 직접 지정할 생각만 했을 것 같네요.


<br>

