### PR TITLE
kitae / 6_week

### DIFF
--- a/Baekjoon/6_week/kitae/단지번호붙이기(2667).py
+++ b/Baekjoon/6_week/kitae/단지번호붙이기(2667).py
@@ -1,0 +1,37 @@
+from collections import deque
+
+dy = [-1,1,0,0]
+dx = [0,0,-1,1]
+
+def bfs(graph, visited, N, y, x):
+  queue = deque()
+  queue.append((y,x))
+  visited[y][x] = True
+  count = 1
+  while queue:
+    yIndex, xIndex = queue.popleft()
+    for i in range(4):
+      ny = yIndex + dy[i]
+      nx = xIndex + dx[i]
+      if 0<=ny<N and 0<=nx<N and graph[ny][nx] == '1' and visited[ny][nx] == False:
+        visited[ny][nx] = True
+        queue.append((ny,nx))
+        count+=1
+  return count
+
+N = int(input())
+visited = [[False for _ in range(N)] for _ in range(N)]
+totalCount = []
+graph = []
+for _ in range(N):
+  tempGraph = list(input())
+  graph.append(tempGraph)
+
+for y in range(N):
+  for x in range(N):
+    if graph[y][x] == '1' and visited[y][x] == False:
+      totalCount.append(bfs(graph,visited,N,y,x))
+totalCount.sort()
+print(len(totalCount))
+for count in totalCount:
+  print(count)


### PR DESCRIPTION
## 첫 번째 문제(2667번) 풀이 방법
### 접근 방식

상하좌우로 탐색하면서 1을 카운트하는 문제이기에 BFS로 쉽게 풀리겠다라고 생각하고 접근했습니다.

### 코드 설명

정말 전형적인 BFS 코드입니다.

우선 이중 반복문으로 graph를 탐색하다가 ‘1’을 만나면 BFS 탐색을 시작합니다. 상하좌우를 탐색할 때마다 count를 늘려줌으로써 마지막 return에 총 ‘1’의 숫자를 return 하게 했습니다.

이중 반복문으로 graph 탐색이 끝나면 ‘1’ 단지의 숫자들이 totalCount에 저장되어 있는데 이를 오름차순으로 정렬해주고 크기, 그리고 각 원소를 출력해주면 끝납니다.

### 후기

실버1치고는 너무 쉬운 BFS 문제인 것 같습니다.## 두 번째 문제(OOOO번) 풀이 방법

### 접근 방식
(설명)

### 코드 설명
(설명)

### 후기
(설명)


<br>

## 세 번째 문제(OOOO번) 풀이 방법

### 접근 방식
(설명)

### 코드 설명
(설명)

### 후기
(설명)


<br>


## 네 번째 문제(OOOO번) 풀이 방법

### 접근 방식
(설명)

### 코드 설명
(설명)

### 후기
(설명)


<br>

